### PR TITLE
Generator Refactor

### DIFF
--- a/GeneratorREADME.md
+++ b/GeneratorREADME.md
@@ -6,7 +6,7 @@
 
 - Docker
 
-Via docker, the appropriate images can be maintained and installed. 
+Via docker, the appropriate images can be maintained and installed.
 You may optionally install [a local PrairieLearn clone](https://github.com/PrairieLearn/PrairieLearn) if you want to tinker with its internals.
 
 
@@ -32,10 +32,10 @@ root-course-directory
 |   |   ...                     <<
 ```
 
-To begin writing any FPP questions, you will need the `pl-faded-parsons` directory and all of its contents. 
+To begin writing any FPP questions, you will need the `pl-faded-parsons` directory and all of its contents.
 It contains all the html and js files required by PrairieLearn to display a `<pl-faded-parsons>` element.
 
-This element is then used by questions you would traditionally write as subfolders in the `questions` directory. 
+This element is then used by questions you would traditionally write as subfolders in the `questions` directory.
 The tool `generate_fpp.py` will take well-formatted python files and turn them into a question folder.
 
 ### Grading
@@ -50,7 +50,7 @@ Any file following the semantic rules (see below) may be provided, but the tool 
 
 This tool will search for a provided path in `./`, `questions/`, `../../questions/`, and finally `../../` before erring.
 If none is provided, it will hunt for a `questions` directory in these locations, and use all .py files there.
- 
+
 ### Semantic Rules
  - If the file begins with a docstring, it will become the question text
      - The question text is removed from the reference answer
@@ -59,7 +59,8 @@ If none is provided, it will hunt for a `questions` directory in these locations
      - Blanks cannot span more than a single line
      - The text within the question marks fills the blank in the answer
      - `?`s in any kind of string-literal or comment are ignored
- - Comments are removed from the prompt unless the comment matches a special form: 
+     - The delimiter can be changed from `?` using the `metadata` region
+ - Comments are removed from the prompt unless the comment matches a special form:
      - `#{n}given`: include as a part of the start solution (n-times-indented)
      - `#blank {txt}`: use txt as the default for a blank in the preceding line
      - These special forms are the only comments removed from the answer
@@ -69,10 +70,10 @@ If none is provided, it will hunt for a `questions` directory in these locations
      - All text in a region is only copied into that region
      - Text will be copied into a new file with the regions name in the
        question directory, excluding these special regions:
-         - explicit: `test` `setup_code`
+         - explicit: `test` `setup_code` `metadata`
          - implicit: `answer_code` `prompt_code` `question_text`
      - Code in `setup_code` will be parsed to extract exposed names unless the --no-parse
-       flag is set. 
+       flag is set.
          - Type annotations and function docstrings are used to fill out `server.py` and the Provided section of the prompt text
      - Any custom region that clashes with an automatically generated file name
        will overwrite the automatically generated code
@@ -126,7 +127,7 @@ Note that the full-line comments as well as the `# return early!` comment will b
 By contrast, the special-form comments (eg `#0given` and `#blank _:_`) will not appear in the reference solution, but will edit the starting configuration of the sortable code lines.
 (`#0given` includes `def is_sublist(lst, sublist):` as a part of the starting solution with 0 indents, `#1given` includes `return False` with 1 indent, and `#blank _:_` sets the initial text of the blank in the brackets to `_:_`. )
 
-There is no way to indicate a red-herring or distractor line! 
+There is no way to indicate a red-herring or distractor line!
 Distractors are philosophically  antithetical to the design of FPPs!
 
 Continuing to the `test` region, the file concludes:
@@ -144,7 +145,7 @@ def score_cases(student_fn, ref_fn, *cases):
         ref_val = ref_fn(*case)
         if user_val == ref_val:
             correct += 1
-    
+
     # set_score must be in range 0.0 to 1.0
     if cases:
         Feedback.set_score(correct / len(cases))
@@ -160,7 +161,7 @@ class Test(PLTestCase):
             ([1, 2, 3, 4], [4, 3])
         )
 
-    
+
     @points(8)
     @name("advanced cases")
     def test_1(self):
@@ -189,9 +190,9 @@ At a glance:
  - Any printing done by the student will automatically be relayed to them in the grading section, but we highly discourage grading printed output.
 
 Common Gotchas:
- - Setting the highest possible points value for a test function is done through `@points`, and the performance is entered on a 0-to-1 scale through `Feedback.set_score`. 
+ - Setting the highest possible points value for a test function is done through `@points`, and the performance is entered on a 0-to-1 scale through `Feedback.set_score`.
  **Entering the number of points received will not work!**
- - Test helper functions (ie `score_cases` in the example above) **cannot** be methods (static or instance) on the Test class. 
+ - Test helper functions (ie `score_cases` in the example above) **cannot** be methods (static or instance) on the Test class.
  They must be defined in a different scope.
 
 
@@ -207,11 +208,11 @@ questions
 Instead of writing a docstring, you may choose to write a file (eg for syntax-highlighting/checking):
 ``` html
 <!-- square_question.html -->
-Make a function <code>square_color</code> that tells if a chess 
+Make a function <code>square_color</code> that tells if a chess
 square is black based off of its position (see the labeled board below).
 <br>
-<img src="https://www.dummies.com/wp-content/uploads/201843.image0.jpg" 
-    alt="chessboard" 
+<img src="https://www.dummies.com/wp-content/uploads/201843.image0.jpg"
+    alt="chessboard"
     style="margin-left:auto; margin-right:auto; display:block; width:50;"
 >
 <br>
@@ -219,11 +220,11 @@ square is black based off of its position (see the labeled board below).
 <h3> Background </h3>
 
 In this activity we will be using modulo (%)! It is often spoken about as
-the remainder, the complement to integer division. We often use it to find if something 
-is even or odd, by inspecting if <code>x % 2 == 0</code> for even and 
+the remainder, the complement to integer division. We often use it to find if something
+is even or odd, by inspecting if <code>x % 2 == 0</code> for even and
 <code>x % 2 == 1</code> for odd.
 
-Another way to think of it is to convert <i>linear</i> change into 
+Another way to think of it is to convert <i>linear</i> change into
 <i>cyclic</i> change. Consider how it acts on this linearly increasing list:
 
 <pl-code language="python">
@@ -254,7 +255,7 @@ def to_coordinates(pos: str) -> tuple[int, int]:
 ## setup_code ##
 ...
 ```
-The `setup_code` region is required to determine that this is not code to be given to the student. 
+The `setup_code` region is required to determine that this is not code to be given to the student.
 They will have no visibility of this code, but its name will be available to them.
 
 This code will be parsed and the type information and documentation extracted.
@@ -296,7 +297,7 @@ will write the single line `3.14159` to `question_name/res/pi.txt`.
 
 ## Generating Boilerplate Tests with `generate_test.py`
 
-Most test files for FPP follow the same pattern as the first example, having a suite of tests, each with their own set of inputs. 
+Most test files for FPP follow the same pattern as the first example, having a suite of tests, each with their own set of inputs.
 The results of applying the reference and student functions to the inputs are used to determine the score for the problem.
 
 The `lib` folder contains a standalone tool called `generate_test.py` that will accept a well-formatted JSON file to create tests.
@@ -317,7 +318,7 @@ The json file must follow this schema:
     }]
 }
 ```
-Note that each case must be a string of the tuple of the arguments for that case, eg the written out case `foo(2, [2, 3], 'hi')` would be the json case `"(2, [2, 3], 'hi')"`. 
+Note that each case must be a string of the tuple of the arguments for that case, eg the written out case `foo(2, [2, 3], 'hi')` would be the json case `"(2, [2, 3], 'hi')"`.
 The enclosing parenthesis may also be omitted, so the case `baz("hello")` could be written `"hello"`.
 
 Tuple generator unpacking is also valid for programmatically listing cases.
@@ -342,7 +343,7 @@ To generate the test file shown in the simple example section, the following jso
       "name": "example cases",
       "points": 2,
       "inputs": [
-          "['a', 'b', 'c', 'd'], ['b', 'c']", 
+          "['a', 'b', 'c', 'd'], ['b', 'c']",
           "[1, 2, 3, 4], [4, 3]"
         ]
     },
@@ -372,12 +373,12 @@ The directory name will be set by the name of the file used to generate the ques
 
 ### The `info.json` File
 
-The `info.json` file will only be generated if a matching file doesn't exist, or if `--force-json file_path` is passed. 
+The `info.json` file will only be generated if a matching file doesn't exist, or if `--force-json file_path` is passed.
 This is so that a new uuid will not be generated each time the file is run.
 
 ### The `server.py` file
 
-The server file specifies which names pass into the student's scope, and which names must pass out of their scope. 
+The server file specifies which names pass into the student's scope, and which names must pass out of their scope.
 The code in the `setup_code` and `prompt_code` regions will be parsed to derive which names enter and exit this scope, and what types they carry.
 
 Parsing of this code can be disabled for an entire batch by the flag `--no-parse`, but it will overwrite any existing `server.py` with the default.
@@ -389,3 +390,13 @@ This is filled with the answer, setup code, and test code.
 This is where the python autograder automatically looks for the files named `ans.py`, `setup_code.py`, and `test.py`.
 
 These are the files that get generated from their respective special name regions.
+
+## The `metadata` region
+
+The `metadata` special region allows for flags to be passed to the problem generator as a JSON. Any unrecognized flags are written into `metadata.json`. Fields the generator recognizes are:
+   - `"noParse": bool` is equivalent to the `--no-parse` command-line argument *(default: `false`)*
+   - `"forceGenerateJson": bool` is equivalent to the `--force-json` command-line argument *(default: `false`)*
+   - `"blankDelimiter"` allows the user to change the delimiters on blanks (fading). The delimiter cannot use any of `, ', ", or #. The value must be:
+     - `string`: A delimiter to use in place of `?`
+     - `{ "start": string, "end": string }`: Delimiters used to indicate the start and end of a blank
+     - `{ "pattern": regex_string }`: a string regular expression pattern that captures the content of blanks. It must capture exactly one group, and cannot match the empty string.

--- a/generate_fpp.py
+++ b/generate_fpp.py
@@ -170,7 +170,6 @@ def generate_fpp_question(
     force_generate_json: bool = False,
     no_parse: bool = False,
     log_details: bool = True,
-    show_required: bool = False
 ):
     """ Takes a path of a well-formatted source (see `extract_prompt_ans`),
         then generates and populates a question directory of the same name.
@@ -197,6 +196,11 @@ def generate_fpp_question(
             del regions[key]
             return v
         return default
+
+    metadata = remove_region('metadata')
+
+    force_generate_json = metadata.get('forceGenerateJson', force_generate_json)
+    no_parse = metadata.get('noParse', no_parse)
 
     question_name = file_name(source_path)
 
@@ -236,7 +240,8 @@ def generate_fpp_question(
         prompt_code,
         question_text=question_text,
         setup_names=setup_names,
-        answer_names=answer_names if show_required else None
+        # show_required removed:
+        # answer_names=answer_names if show_required else None
     )
 
     write_to(question_dir, 'question.html', question_html)
@@ -267,8 +272,6 @@ def generate_fpp_question(
         test_region,
         log_details = log_details
     )
-
-    metadata = remove_region('metadata')
 
     if metadata:
         write_to(question_dir, 'metadata.json', dumps(metadata))

--- a/lib/autograde.py
+++ b/lib/autograde.py
@@ -19,7 +19,7 @@ class AutograderConfig(ABC):
     @abstractmethod
     def info_json_update(self) -> Dict[str, Union[str, Dict[str, Union[bool, str, int]]]]:
         pass
-    
+
     @abstractmethod
     def populate_tests_dir(self, test_dir: str, answer_code: str, setup_code: str, test_region: str, pre_code: str='', post_code: str='', log_details: bool= True) -> None:
         pass
@@ -51,7 +51,7 @@ class PythonAutograder(AutograderConfig):
             }
         }
 
-    def populate_tests_dir(self, test_dir: str, answer_code: str, setup_code: str, test_region: str, 
+    def populate_tests_dir(self, test_dir: str, answer_code: str, setup_code: str, test_region: str,
                     pre_code: str='', post_code: str='', log_details: bool= True) -> None:
         test_region = test_region if test_region != "" else TEST_DEFAULT
         try:
@@ -60,7 +60,7 @@ class PythonAutograder(AutograderConfig):
                 success, test_file = True, make_test_file(json)
             except Exception as e:
                 success, test_file = False, test_region
-            
+
             if success and log_details:
                 Bcolors.info('  - Generating tests/test.py from json test region')
                 write_to(test_dir, 'test_source.json', test_region)
@@ -69,7 +69,7 @@ class PythonAutograder(AutograderConfig):
                 Bcolors.fail('    * Generating tests from json failed with error:', e.msg)
                 Bcolors.warn('    - Recovering by using test region as python file')
             test_file = test_region
-        
+
         write_to(test_dir, 'test.py', test_file)
         write_to(test_dir, 'ans.py', answer_code)
         write_to(test_dir, 'setup_code.py', setup_code)
@@ -93,12 +93,12 @@ class RubyAutograder(AutograderConfig):
             }
         }
 
-    def populate_tests_dir(self, test_dir: str, answer_code: str, setup_code: str, test_region: str, 
+    def populate_tests_dir(self, test_dir: str, answer_code: str, setup_code: str, test_region: str,
                     pre_code: str='', post_code: str='', log_details: bool= True) -> None:
         app_dir = path.join(path.dirname(f"{test_dir}/"), "app")
         spec_dir = path.join(path.dirname(f"{app_dir}/"), "spec")
         makedirs(spec_dir, exist_ok=True)
-        
+
         if log_details:
             Bcolors.info('  - Generating grader metadata')
 
@@ -106,7 +106,7 @@ class RubyAutograder(AutograderConfig):
             "submission_file": "script.rb",
             "submission_root": "",
             "submit_to_line" : 0, # TODO: fix
-            "pre-text": f"{pre_code}\n", 
+            "pre-text": f"{pre_code}\n",
             "post-text": f"{post_code}\n",
             "grading_exclusions" : [
             ]
@@ -118,6 +118,6 @@ class RubyAutograder(AutograderConfig):
         write_to(test_dir, 'meta.json', metadata)
         write_to(test_dir, 'solution', answer_code)
 
-    def generate_server(self, setup_code: str, answer_code: str, *, 
+    def generate_server(self, setup_code: str, answer_code: str, *,
                     no_ast: bool = False, tab: str = '    ') -> tuple[str, list[AnnotatedName], list[AnnotatedName]]:
         return super().generate_server(setup_code, answer_code, no_ast=no_ast, tab=tab)

--- a/lib/consts.py
+++ b/lib/consts.py
@@ -1,6 +1,4 @@
-from typing import *
-
-from os.path import join
+from typing import Final
 from re import compile, Pattern
 
 
@@ -58,7 +56,7 @@ class Test(PLTestCase):
     @name("test 0")
     def test_0(self):
         points = 0
-        # ex: calling a student defined function det 
+        # ex: calling a student defined function det
         #     with args=(1, 2, 3, 4)
         # case = [1, 2, 3, 4]
         # user_val = Feedback.call_user(self.st.det, *case)
@@ -70,7 +68,7 @@ class Test(PLTestCase):
         # ex: test correctness, update points
         # if Feedback.check_scalar('case: ' + case, ref_val, user_val):
         #     points += 1
-        
+
         Feedback.set_score(points)\n"""
 
 SETUP_CODE_DEFAULT: Final[str] = """# AUTO-GENERATED FILE
@@ -97,34 +95,36 @@ def generate(data):
     return data\n"""
 
 # Matches, with precedence in listed order:
-MAIN_PATTERN: Final[Pattern] = compile(
+MAIN_PATTERN: Final[Pattern] = compile('|'.join((
     # - capture group 0: (one-line) region delimiter surrounded by ##'s
     #                    (capturing only the text between the ##'s).
     #                    Consumes leading newline and surrounding spaces/tabs,
     #                    and if the next line doesn't have a region comment,
     #                    it consumes the trailing newline as well.
-    r'(?:\r?\n|^)[ \t]*\#\#[\t ]*(.*?)\s*\#\#.*?(?:(?=\r?\n[ \t]*\#\#)|\r?\n|$)|' +
+    r'(?:\r?\n|^)[\t ]*##[\t ]+(\S.*?)[\t ]+##.*?(?:(?=\r?\n[\t ]*##[^#])|\r?\n|$)',
     # - capture group 1:  (one-line) comment, up to next comment or newline
     #                     (excluding the newline/eof)
-    r'(\#.*?)(?=\#|\r?\n|$)|' +
-    # - capture group 2: (multi-line) triple-quote string literal
-    r'(\"\"\"[\s\S]*?\"\"\")|' +
+    r'(#.*?)(?=#|\r?\n|$)',
+    # - capture group 2:
+    #     - (multi-line) triple-apostrophe string literal
+    #     - (multi-line) triple-quote string literal
+    r'(\'\'\'[\s\S]*?\'\'\'|\"\"\"[\s\S]*?\"\"\")',  # [\s\S] includes newlines! don't change!
     # - capture group 3:
+    #     - (one-line) single-backtick string literal
     #     - (one-line) single-apostrophe string literal
     #     - (one-line) single-quote string literal
-    r'(\'.*?\'|\".*?\")|' +
-    # - capture group 4:  (one-line) answer surrounded by ?'s (excluding ?'s)
-    r'\?(.*?)\?'
-)
+    r'(\`.*?\`|\'.*?\'|\".*?\")'
+)))
 
 SPECIAL_COMMENT_PATTERN: Final[Pattern] = compile(
-    r'^#(blank[^#]*|\d+given)\s*'
+    r'^#(blank[^#]*|\d+given)'
 )
 
+DEFAULT_BLANK_PATTERN: Final[Pattern] = compile(r'\?(.*?)\?')
 BLANK_SUBSTITUTE: Final[str] = '!BLANK'
 
 REGION_IMPORT_PATTERN: Final[Pattern] = compile(
-    r'^\s*import\s*(\w.*)\s+as\s+(\w.*?)\s*$'
+    r'^\s*import\s*(.+?)\s+as\s+(.+?)\s*$'
 )
 
 PROGRAM_DESCRIPTION: Final[str] = Bcolors.f(Bcolors.OK_GREEN, ' A tool for generating faded parsons problems.') + """

--- a/lib/generate_test.py
+++ b/lib/generate_test.py
@@ -19,7 +19,7 @@ def score_cases(student_fn, ref_fn, *cases):
         ref_val = ref_fn(*case)
         if user_val == ref_val:
             correct += 1
-    
+
     # set_score must be in range 0.0 to 1.0
     if cases:
         Feedback.set_score(correct / len(cases))
@@ -133,10 +133,10 @@ def __main__():
     parser.add_argument('path_to_json', help='a path to a well formatted json')
 
     args = parser.parse_args()
-    
+
     with open(args.path_to_json, 'r') as f:
         json = load(f)
-    
+
     print(make_test_file(json))
 
 

--- a/lib/name_visitor.py
+++ b/lib/name_visitor.py
@@ -1,7 +1,7 @@
 from ast import *
-from typing import Union, Any
 
 from dataclasses import dataclass
+from typing import Union, Any
 
 from lib.consts import Bcolors, SERVER_DEFAULT
 
@@ -120,7 +120,7 @@ def generate_server(setup_code: str, answer_code: str, *,
         , (1, '# Define incoming variables here')
         , (1, 'names_for_user = [')
         ]
-    
+
     if setup_names:
         lines.extend((2, format_annotated_name(n)) for n in setup_names)
     else:
@@ -133,13 +133,13 @@ def generate_server(setup_code: str, answer_code: str, *,
         , (1, '# Define outgoing variables here')
         , (1, 'names_from_user = [')
         ]
-    
+
     if answer_names:
         lines.extend((2, format_annotated_name(n)) for n in answer_names)
     else:
         lines.append((2, '# ex: student defines a determinant function name det'))
         lines.append((2, '# {"name": "det", "description": "determinant for a 2x2 matrix", "type": "python function"}'))
-    
+
     lines += \
         [ (1, ']')
         , (0, '')

--- a/lib/tokens.py
+++ b/lib/tokens.py
@@ -1,0 +1,186 @@
+from dataclasses import dataclass, field
+from enum import IntEnum
+from json import JSONDecoder
+from re import Pattern, finditer, match as test
+from typing import Any
+
+from lib.consts import MAIN_PATTERN, REGION_IMPORT_PATTERN
+from lib.io_helpers import read_region_source_lines, format_ln
+
+
+@dataclass(frozen=True, slots=True)
+class RegionDelim:
+    lineno: int
+    name: str
+
+
+class TokenType(IntEnum):
+    COMMENT = -1
+    UNMATCHED = 0
+    STRING = 1
+    DOCSTRING = 2
+
+
+@dataclass(frozen=True, slots=True)
+class Token:
+    """ A record representing a single token of text """
+    lineno: int
+    type: TokenType
+    text: str
+    region: str
+
+
+@dataclass(frozen=True, slots=True)
+class Tokens:
+    """ A record of source_path, data, and metadata from a lex """
+    source_path: str
+    data: list[Token]
+    metadata: dict[str, Any]
+
+
+@dataclass(slots=True)
+class Lexer:
+    """ A helper class for lexing """
+    source_path: str = None
+    data: list[Token] = field(default_factory=list)
+    current_region: RegionDelim = None
+
+    def format_ln(self, line_number: int):
+        return format_ln(self.source_path, line_number)
+
+    def put(self, t: Token):
+        self.data.append(t)
+
+    def put_curr(self, lineno: int, type: TokenType, text: str):
+        curr_region = self.current_region.name if self.current_region else ''
+        self.put(Token(lineno, type, text, curr_region))
+
+    def put_region_delim(self, region_delim: str, lineno: int):
+        if not len(region_delim):
+            raise SyntaxError("Regions must be named (ie ## test ##) " +
+                self.format_ln(lineno))
+
+        if self.current_region:
+            if region_delim != self.current_region.name:
+                raise SyntaxError("Region \"{}\" began at {} before \"{}\" ended.".format(
+                    region_delim,
+                    self.format_ln(lineno),
+                    self.current_region.lineno,
+                ))
+
+            self.current_region = None
+            return
+
+        import_region = test(REGION_IMPORT_PATTERN, region_delim)
+
+        if not import_region:
+            self.current_region = RegionDelim(lineno + 1, region_delim)
+            if any(t.region == region_delim and t.text for t in self.data):
+                self.put_curr(lineno, TokenType.UNMATCHED, '\n')
+            return
+
+        region_source, alias = import_region.groups()
+        try:
+            imported_lines = read_region_source_lines(self.source_path, region_source)
+            imported_regions = lex(imported_lines, source_path=self.source_path)
+            for t in imported_regions.data:
+                if t.region:
+                    raise SyntaxError('Imported regions cannot contain regions. ' +
+                        self.format_ln(lineno))
+                self.put(Token(lineno, t.type, t.text, alias))
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                "Region \"{}\" failed on import. Could not find {} at {}".format(
+                    alias, region_source, self.format_ln(lineno)))
+        except OSError as e:
+            raise OSError(
+                "Region \"{}\" failed on import. Could not read {}:\n\t\t{}\n\tat {}".format(
+                    alias, region_source, e.strerror, self.format_ln(lineno)))
+
+    def finish(self) -> Tokens:
+        if self.current_region:
+            raise SyntaxError("File ended before \"{}\" {} ended".format(
+                self.current_region.name,
+                self.format_ln(self.current_region.lineno)
+            ))
+
+        def unparse(tkns: list[Token]):
+            return ''.join(q_tkn.text for q_tkn in tkns)
+
+        data = []
+        metadata = []
+        for t in self.data:
+            if t.region == 'metadata':
+                metadata.append(t)
+            else:
+                data.append(t)
+
+        if metadata:
+            metadata = unparse(metadata)
+            # strict allows control chars (\n \t \r) in strings
+            metadata = metadata and JSONDecoder(strict=False).decode(metadata)
+
+        # replace None, 0, '', or [] with {}
+        metadata = metadata or {}
+
+        if not isinstance(metadata, dict):
+            raise SyntaxError('Metadata region must be empty or a JSON object.')
+
+        return Tokens(self.source_path, data, metadata)
+
+
+def regex_chunk_lines(pattern: Pattern, txt: str, *, line_number = 1):
+    """ Chunks `txt` up using `finditer(pattern)`, alternating
+        between `pattern` matches and unmatched pieces of `txt`.
+
+        Yields the line number of the start of the chunk, the success flag,
+        and chunk data. If the success flag is `True`, then the chunk data
+        is an `re.Match` object. Otherwise (when the success flag is false)
+        the chunk data is a `str` object containing all the text that did
+        not match the pattern.
+    """
+    last_end = 0
+    for match in finditer(pattern, txt):
+        start, end = match.span()
+
+        unmatched = txt[last_end:start]
+        yield (line_number, False, unmatched)
+
+        line_number += sum(1 for x in unmatched if x == '\n')
+        last_end = end
+
+        yield (line_number, True, match)
+
+        line_number += sum(1 for x in txt[start:end] if x == '\n')
+
+    # don't forget everything after the last match!
+    unmatched = txt[last_end:]
+    yield (line_number, False, unmatched)
+
+
+def lex(source_code: str, *, source_path: str = None) -> Tokens:
+    """ Get the tokens from source_code """
+    # (exclusive) end of the last match
+    lexer = Lexer(source_path)
+
+    for line_number, found, chunk in regex_chunk_lines(MAIN_PATTERN, source_code):
+        # found is False when chunk is the text between matches
+        if not found:
+            lexer.put_curr(line_number, TokenType.UNMATCHED, chunk)
+            continue
+
+        # exactly one is non-None
+        region_delim, comment, docstring, string = chunk.groups()
+
+        if region_delim:
+            lexer.put_region_delim(region_delim, line_number)
+        elif comment:
+            lexer.put_curr(line_number, TokenType.COMMENT, comment)
+        elif docstring:
+            lexer.put_curr(line_number, TokenType.DOCSTRING, docstring)
+        elif string:
+            lexer.put_curr(line_number, TokenType.STRING, string)
+        else:
+            raise Exception("Unreachable! Inexhaustive match groups.\n", f"{line_number=}, {found=} \n{chunk.groups()}")
+
+    return lexer.finish()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,681 @@
+assert __name__ == '__main__', "lib/test cannot be imported as a module."
+
+import requests
+
+from abc import ABC
+from collections import defaultdict
+from itertools import cycle
+from json import JSONDecoder, dumps
+from unittest import TestCase, main
+from unittest.mock import patch, mock_open
+
+from lib.consts import DEFAULT_BLANK_PATTERN, BLANK_SUBSTITUTE
+from lib.tokens import Lexer, lex
+from generate_fpp import parse_fpp_regions
+
+def flatten_into_region_map(tokens: Lexer) -> dict[str, list[str]]:
+    col = defaultdict(list)
+    for t in tokens.data:
+        col[t.region].append(t.text)
+    return { k: ''.join(v) for k, v in col.items() }
+
+def make_region(name: str, body: str) -> str:
+    return f'## {name} ##\n{body}\n## {name} ##'
+
+def make_import(path: str, name: str) -> str:
+    return f'## import {path} as {name} ##'
+
+def make_metadata_region(**metadata):
+    return make_region('metadata', dumps(metadata))
+
+def lines(*lines): return '\n'.join(lines)
+def n_lines(n: int, body: str): return '\n'.join(n * [body])
+
+class TestLexABC(TestCase, ABC):
+    def assertLexesTo(self, src: str, *, no_region='', **output):
+        lexed = lex(src)
+        rmap = flatten_into_region_map(lexed)
+        output.setdefault('', no_region)
+        self.assertDictEqual(output, rmap, msg=f'\n\nSource:\n{src}')
+
+    def assertMetadataIs(self, src: str, **output):
+        lexed = lex(src)
+        self.assertDictEqual(output, lexed.metadata, msg=f'\n\nSource:\n{src}')
+
+    def assertNoRegions(self, src: str):
+        self.assertLexesTo(src, no_region=src)
+
+    def assertSyntaxError(self, src: str):
+        with self.assertRaises(SyntaxError):
+            _ = lex(src)
+
+
+class TestLex(TestLexABC):
+    def test_empty_src(self):
+        """ An empty source should return `{ '': '' }` """
+        self.assertLexesTo('')
+
+    def test_simple_region_delims(self):
+        """ Single char names and ws only contents """
+        txt = '## r ##\n## r ##'
+        self.assertLexesTo(txt, r='')
+        txt += '\n'
+        self.assertLexesTo(txt, r='')
+        txt += '\n'
+        self.assertLexesTo(txt, no_region='\n', r='')
+
+        # these seem iffy!
+        txt = '## r ##\n\n## r ##'
+        self.assertLexesTo(txt, r='')
+        txt = '## r ##\n\n\n## r ##'
+        self.assertLexesTo(txt, r='\n')
+
+    def test_dirty_region_delims(self):
+        """ Whitespace before and text after region delim tags is ignored """
+        txt = """
+           \t ## dirty ## hi there! ##
+        all good
+        ## dirty #### random text $$%$%"""
+        self.assertLexesTo(txt, dirty='        all good')
+
+    def test_unbalanced_region_delims(self):
+        """ Checks unbalanced delims throw SyntaxErrors """
+        with self.subTest('unbalanced w/valid start'):
+            txt = "## not_okay ##\n"
+            self.assertSyntaxError(txt)
+            # with contents/no-region text
+            txt = "outer text\n\n## not_okay ##\n\ninner text...\n"
+            self.assertSyntaxError(txt)
+            # dirty start
+            txt = f"\t\t## region ### hi"
+            self.assertSyntaxError(txt)
+
+        with self.subTest('integration'):
+            # after good regions
+            txt = f"a \n{make_region('r0', 'hi there')} \nb \n## bad ##\n inner"
+            self.assertSyntaxError(txt)
+
+    def test_start_region_without_closing_previous(self):
+        """ Region delimiters appearing in regions throw SyntaxErrors """
+        # balanced
+        txt = make_region('okay', "text\n " + make_region("not okay", "bad") + "\n more text")
+        self.assertSyntaxError(txt)
+        # unbalanced, after good
+        txt = f"a \n{make_region('r0', 'hi there')} \n{make_region('r1', '## bad ##')}"
+        self.assertSyntaxError(txt)
+
+    def test_import_region_without_closing_previous(self):
+        """ Import regions appearing in regions throw SyntaxErrors """
+        i_r = make_import("file.txt", "bad")
+        txt = make_region('okay', f"text\n{i_r}\n more text")
+        self.assertSyntaxError(txt)
+        # after good
+        txt = f"a \n{make_region('r0', 'hi there')} \n{make_region('r1', i_r)}"
+        self.assertSyntaxError(txt)
+
+    def test_almost_region_delim_false_positives(self):
+        """ Test things that almost qualify as region delims """
+        with self.subTest('regions must be named'):
+            self.assertNoRegions('####')
+            self.assertNoRegions('#####')
+
+        with self.subTest('regions must be named non whitespace'):
+            self.assertNoRegions('## ##')
+            self.assertNoRegions('## \t ##')
+            self.assertNoRegions('## \t   ##')
+
+        with self.subTest('regions begin with exactly ## and end with at least ##'):
+            self.assertNoRegions('### region ##')
+            # self.assertNoRegions('## region ###') << this is a valid (but dirty ended) delim!
+            self.assertNoRegions('# region ##')
+            self.assertNoRegions('### region ###')
+            self.assertNoRegions('#### region ####')
+
+    def test_region_concat(self):
+        """ Regions with the same name should concatenate in the order they appear """
+        rbody = 'body 0\nbody1\nbody2\n\n'
+        r = make_region('r', rbody) + '\n'
+        self.assertLexesTo(3 * r, r = n_lines(3, rbody))
+        sbody = 'body a\nbodyb\nbodyc\n\n'
+        s = make_region('s', sbody) + '\n'
+        self.assertLexesTo(r + s + r + s + r, s = n_lines(2, sbody), r = n_lines(3, rbody))
+
+        txt = '\n'.join((make_region('r', '1'), make_region('r', '2'), make_region('r', '3')))
+        self.assertLexesTo(txt, r=lines('1', '2', '3'))
+
+    def test_empty_metadata(self):
+        """ Empty input or metadata regions should both yield {} metadata """
+        self.assertMetadataIs('')
+        self.assertMetadataIs(make_region('metadata', ''))
+
+    def test_falsy_metadata(self):
+        """ Falsy objects in metadata is interpreted as {} """
+        self.assertMetadataIs('')
+        self.assertMetadataIs(make_region('metadata', '0'))
+        self.assertMetadataIs(make_region('metadata', '[]'))
+        self.assertMetadataIs(make_region('metadata', '{}'))
+        self.assertMetadataIs(make_region('metadata', '""'))
+        self.assertMetadataIs(make_region('metadata', 'null'))
+        # stitch together many
+        txt = make_region('metadata', '') + '\n' + make_region('metadata', '{}') + \
+            '\n' + make_region('metadata', '')
+        self.assertMetadataIs(txt)
+
+    def test_import_concat(self):
+        """ Check that import regions concat to themselves like regular regions """
+        file_data = 'imported file:\n3\n2\n1'
+        with patch('builtins.open', mock_open(read_data=file_data)):
+            i_r = make_import('file.txt', 'imported')
+            txt = i_r + '\n' + make_region('r', 'data') + ('\n' + i_r) * 2
+            self.assertLexesTo(txt, r='data', imported=3*file_data)
+
+    def test_multiple_imports(self):
+        """ Importing multiple sources is possible """
+        file_data = 'imported file:\n3\n2\n1'
+        with patch('builtins.open', mock_open(read_data=file_data)):
+            txt = make_region('r', 'data') + '\n' + \
+                make_import('f1.txt', 'i1') + '\n' + \
+                    make_import('f2.txt', 'i2')
+            self.assertLexesTo(txt, i1=file_data, i2=file_data, r='data')
+
+    def test_valid_import(self):
+        """ Valid imports read file contents """
+        path = 'README.md'
+        with open(path) as rdme:
+            lines = ''.join(rdme.readlines())
+        txt = make_import(path, 'readme')
+        self.assertLexesTo(txt, readme=lines)
+
+    def test_valid_import_content(self):
+        """ Valid imports read file contents and do not edit other regions """
+        file_data = 'imported file:\n3\n2\n1'
+        with patch('builtins.open', mock_open(read_data=file_data)):
+            i_r = make_import('file.txt', 'imported')
+            self.assertLexesTo(i_r, imported=file_data)
+
+            txt = make_region('r', 'data') + '\n' + i_r
+            self.assertLexesTo(txt, imported=file_data, r='data')
+
+    def test_import_bad_path(self):
+        """ Bad import paths result in FileNotFoundErrors or OSErrors """
+        with self.subTest('absolute dir'):
+            path = '~/Documents'
+            with self.assertRaises(OSError):
+                _ = lex(make_import(path, 'imported'))
+
+        with self.subTest('absolute non-existent file'):
+            path = '~/badsasdfasdfasdfasdfsadfas.txt'
+            with self.assertRaises(FileNotFoundError):
+                _ = lex(make_import(path, 'imported'))
+
+        with self.subTest('relative dir'):
+            path = './lib'
+            with self.assertRaises(OSError):
+                _ = lex(make_import(path, 'imported'))
+
+        with self.subTest('relative non-existent file'):
+            path = './dont-readme.md'
+            with self.assertRaises(FileNotFoundError):
+                _ = lex(make_import(path, 'imported'))
+
+        with self.subTest('unix-style relative non-existent file'):
+            path = 'badsasdfasdfasdfasdfsadfas.txt'
+            with self.assertRaises(FileNotFoundError):
+                _ = lex(make_import(path, 'imported'))
+
+    def test_import_json_as_metadata(self):
+        """ Reading a metadata json with imports is the same as with decoders """
+        with open('./info.json') as f:
+            ls = ''.join(f.readlines())
+        txt = make_import('info.json', 'metadata') # a fixture of PL elements
+        json = JSONDecoder().decode(ls)
+        self.assertMetadataIs(txt, **json)
+
+
+class TestRandomLex(TestLexABC):
+    @staticmethod
+    def get_bacon_ispum(paragraphs):
+        res = requests.get(
+            url = 'https://baconipsum.com/api/',
+            params = {
+                'type': 'meat-and-filler',
+                'paras': paragraphs,
+            }
+        )
+        assert res.status_code == 200, f"Bad result: {res}"
+        return JSONDecoder().decode(res.text)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.test_strings = cls.get_bacon_ispum(10)
+
+    def test_no_regions(self):
+        """ A random text file with no regions of any kind. """
+        self.assertNoRegions(self.test_strings[0])
+
+    def test_empty_regions(self):
+        """ A randomly named set of empty regions """
+        rnames = self.test_strings[0].split()[:3]
+        txt = '\n'.join(make_region(name, '') for name in rnames)
+        output = { name: '' for name in rnames }
+        self.assertLexesTo(txt, **output)
+
+    def test_random_regions(self):
+        """ A randomly filled and named set of regions """
+        rnames = self.test_strings[0].split()[:3]
+        rbodies = self.test_strings[1:4]
+        txt = '\n'.join(make_region(name, body) for name, body in zip(rnames, rbodies))
+        output = defaultdict(str)
+        for name, body in zip(rnames, rbodies):
+            output[name] += body
+        output[''] += ''
+        self.assertLexesTo(txt, **output)
+
+    def test_mixed_regions_and_no_region(self):
+        """ A randomly filled and named set of regions, interspersed with random text """
+        str_iter = iter(self.test_strings)
+        rnames = cycle(next(str_iter).split()[:3])
+        txt = []
+        output = defaultdict(list)
+        unmatched = ''
+        for name, body, no_r in zip(rnames, str_iter, str_iter):
+            txt.append(make_region(name, body))
+            output[name].append(body)
+
+            txt.append(no_r)
+            unmatched += no_r
+
+        output = { name: lines(*body) for name, body in output.items() }
+        output[''] = unmatched
+        self.maxDiff = 5000
+        self.assertLexesTo(lines(*txt), **output)
+
+def scrub_blank(txt: str): return txt.replace('?', '')
+def sub_blank(txt: str): return DEFAULT_BLANK_PATTERN.sub(lambda _: BLANK_SUBSTITUTE, txt)
+
+class TestParseFPP(TestCase):
+    def assertParsesTo(self, src: str, *, answer_code='', prompt_code='', metadata=None, **output):
+        lexed = lex(src)
+        parsed = parse_fpp_regions(lexed)
+        output.setdefault('metadata', metadata or {})
+        output.setdefault('answer_code', answer_code)
+        output.setdefault('prompt_code', prompt_code)
+        self.assertDictEqual(output, parsed, msg=f'\n\nSource:\n{src}')
+
+    def assertSyntaxError(self, src: str):
+        lexed = lex(src)
+        with self.assertRaises(SyntaxError):
+            _ = parse_fpp_regions(lexed)
+
+    def test_empty_src(self):
+        """ Empty source results in {} metadata and blank answer_code and prompt_code """
+        self.assertParsesTo('') # defaults are all blank...
+
+    def test_no_comments_in_strings(self):
+        """ Comments are not captured in str literals """
+        for c in ["'", '"', '`', '"""', "'''"]:
+            with self.subTest(f'no comments within {c}s'):
+                txt = 's = " line# 7 "'
+                self.assertParsesTo(
+                    txt,
+                    answer_code=txt,
+                    prompt_code=txt,
+                )
+
+    def test_docstring_question_text(self):
+        """ Leading docstrings are appended to the question_text region """
+        q_html = '<question> text </question>'
+        ans = 'answer = 3'
+        self.assertParsesTo(
+            lines(f"'''{q_html}'''", '', ans),
+            answer_code=ans,
+            prompt_code=ans,
+            question_text=q_html
+        )
+        t = '<i>hello</i>'
+        r = make_region('question_text', t)
+        self.assertParsesTo(
+            lines(f"'''{q_html}'''", '', ans, r),
+            answer_code=ans,
+            prompt_code=ans,
+            question_text=lines(q_html, t)
+        )
+        self.assertParsesTo(
+            lines(r, f"'''{q_html}'''", '', ans, r),
+            answer_code=ans,
+            prompt_code=ans,
+            question_text=lines(t, q_html, t)
+        )
+
+    def test_regular_comment_splitting(self):
+        """ Regular comments should only appear in prompt_code not answer_code """
+        txt = lines('# c0', 'a = 4  # c1', 'a += 2', '\t\t# c1', '')
+        self.assertParsesTo(
+            txt,
+            answer_code = txt.strip(),
+            prompt_code = lines('a = 4', 'a += 2')
+        )
+
+    def test_blank_parsing(self):
+        """ Blanks appear between ?'s by default, are substituted with lib.consts.BLANK_DEFAULT
+            in the answer_code. The question marks are removed from the answer code.
+        """
+        txt = lines('for ?i? in range(?1, 10?):', '\t?a? += i', '?return a?')
+        self.assertParsesTo(
+            txt,
+            answer_code = scrub_blank(txt),
+            prompt_code = sub_blank(txt)
+        )
+
+        # ignores incomplete fades, and fades completed in comments or strs
+        txt = lines('for _ in range?(1, 10):', '\ta? += "?"', 'return a.is_odd? # fun?')
+        self.assertParsesTo(
+            txt,
+            answer_code = txt,
+            prompt_code = lines('for _ in range?(1, 10):', '\ta? += "?"', 'return a.is_odd?')
+        )
+
+    def test_given_special_comment(self):
+        """ Special comments appear in the prompt_code, but not the answer_code.
+            The special comment that indicates a line as given in the prompt are
+            /#<indentation level>given/
+        """
+        txt = lines('def foo(x): #0given', '\tx *= x', '\treturn x #1given', '')
+        self.assertParsesTo(
+            txt,
+            answer_code = lines('def foo(x):', '\tx *= x', '\treturn x'),
+            prompt_code = txt.strip()
+        )
+
+        txt = lines('def foo(x): #10000given', '\tx *= x', '\treturn x #000given', '')
+        self.assertParsesTo(
+            txt,
+            answer_code = lines('def foo(x):', '\tx *= x', '\treturn x'),
+            prompt_code = txt.strip()
+        )
+
+        with self.subTest('poorly formatted special comments become regular comments'):
+            # poorly formatted
+            txt = lines('def foo(x): #-10000given', '\tx *= x', '\treturn x #given', '')
+            self.assertParsesTo(
+                txt,
+                answer_code = txt.strip(),
+                prompt_code = lines('def foo(x):', '\tx *= x', '\treturn x')
+            )
+
+    def test_blank_default_special_comment(self):
+        """ Special comments appear in the prompt_code, but not the answer_code.
+            The special comment that indicates placeholder text for a fade is
+            /#blank <blank placeholder text>/
+        """
+        txt = lines('x, y = a[?3:-3?]  #blank _:_')
+        self.assertParsesTo(
+            txt,
+            answer_code = 'x, y = a[3:-3]',
+            prompt_code = sub_blank(txt)
+        )
+        txt = lines('x, y = a[?3:-3?]  #blank')
+        self.assertParsesTo(
+            txt,
+            answer_code = 'x, y = a[3:-3]',
+            prompt_code = sub_blank(txt)
+        )
+
+        with self.subTest('poorly formatted special comments become regular comments'):
+            txt = lines('x, y = a[?3:-3?]  #blahblah _:_')
+            self.assertParsesTo(
+                txt,
+                answer_code = scrub_blank(txt),
+                prompt_code = sub_blank('x, y = a[?3:-3?]')
+            )
+
+    def test_many_comments(self):
+        """ Interspersing special and regular comments does not effect behavior """
+        txt = lines(
+            'def func(x: ?str?): #0given #blank _type_',
+            '\tx.modify(42) # 42 is always magic ',  # << !! trailing space is cut
+            '\treturn ?x.finish()? #1given #blank x._ # huzzah!'
+        )
+        self.assertParsesTo(
+            txt,
+            answer_code = scrub_blank(lines(
+                'def func(x: ?str?):',
+                '\tx.modify(42) # 42 is always magic',
+                '\treturn ?x.finish()? # huzzah!'
+            )),
+            prompt_code=sub_blank(lines(
+                'def func(x: ?str?): #0given #blank _type_',
+                '\tx.modify(42)',
+                '\treturn ?x.finish()? #1given #blank x._'
+            ))
+        )
+
+    def test_custom_fading(self):
+        """ Blank delimiters can be set through a field 'blankDelimiter' in the metadata
+            by one of three values:
+                - a str that is the stop & start delimiter
+                - an `{ 'start': str, 'stop': str }` object
+                - an `{ 'pattern': regex_str }` object
+
+            Delimiters may be special characters in regex, but are not treated as regex
+            unless the 'pattern' tag is specified. (e.g. 'blankDelimiter': '$' means
+            that $x$ is a valid fade.)
+        """
+        metadata = { 'blankDelimiter': '--' }
+        self.assertParsesTo(
+            lines(
+                make_metadata_region(**metadata),
+                '',
+                '4.--times-- do #blank _verb_',
+                '\tputs --i.?dis?belief??--',
+                'end',
+                ''
+            ),
+            metadata = metadata,
+            answer_code = lines(
+                '4.times do',
+                '\tputs i.?dis?belief??',
+                'end'
+            ),
+            prompt_code = lines(
+                f'4.{BLANK_SUBSTITUTE} do #blank _verb_',
+                f'\tputs {BLANK_SUBSTITUTE}',
+                'end'
+            )
+        )
+
+        with self.subTest('works with regex reserved chars'):
+            metadata = { 'blankDelimiter': '$' }
+            self.assertParsesTo(
+                lines(
+                    make_metadata_region(**metadata),
+                    '',
+                    '4.$times$ do #blank _verb_',
+                    '\tputs $i.?dis?belief??$',
+                    'end',
+                    ''
+                ),
+                metadata = metadata,
+                answer_code = lines(
+                    '4.times do',
+                    '\tputs i.?dis?belief??',
+                    'end'
+                ),
+                prompt_code = lines(
+                    f'4.{BLANK_SUBSTITUTE} do #blank _verb_',
+                    f'\tputs {BLANK_SUBSTITUTE}',
+                    'end'
+                )
+            )
+
+            metadata = { 'blankDelimiter': { 'start': '^', 'end': '$' } }
+            self.assertParsesTo(
+                lines(
+                    make_metadata_region(**metadata),
+                    '',
+                    '4.^times$ do #blank _verb_',
+                    '\tputs ^i.?dis?belief??$',
+                    'end',
+                    ''
+                ),
+                metadata = metadata,
+                answer_code = lines(
+                    '4.times do',
+                    '\tputs i.?dis?belief??',
+                    'end'
+                ),
+                prompt_code = lines(
+                    f'4.{BLANK_SUBSTITUTE} do #blank _verb_',
+                    f'\tputs {BLANK_SUBSTITUTE}',
+                    'end'
+                )
+            )
+
+        with self.subTest('custom regex pattern'):
+            metadata = { 'blankDelimiter': { 'pattern': r'--(.+?)%-%' } }
+            self.assertParsesTo(
+                lines(
+                    make_metadata_region(**metadata),
+                    '',
+                    '4.--times%-% do #blank _verb_',
+                    '\tputs --i.?dis?belief??%-%',
+                    'end',
+                    ''
+                ),
+                metadata = metadata,
+                answer_code = lines(
+                    '4.times do',
+                    '\tputs i.?dis?belief??',
+                    'end'
+                ),
+                prompt_code = lines(
+                    f'4.{BLANK_SUBSTITUTE} do #blank _verb_',
+                    f'\tputs {BLANK_SUBSTITUTE}',
+                    'end'
+                )
+            )
+
+
+    def test_illegal_custom_fading(self):
+        """ Custom fading cannot use a builtin delimiter (` ' " #), must
+            capture exactly one substring when it matches, and must not
+            match on the empty string
+        """
+        def assertBadCustomDelim(*args, **kwargs):
+            delim = args[0] if args else kwargs
+            metadata = make_metadata_region(blankDelimiter=delim)
+            self.assertSyntaxError(metadata)
+
+        for c in '#`\'"':
+            with self.subTest(f'cannot shadow builtin delimiter {c}'):
+                assertBadCustomDelim(c)
+                assertBadCustomDelim(start = '-', end = c )
+                assertBadCustomDelim(start = c, end = '-' )
+                assertBadCustomDelim(pattern = c + r'(.+?)-')
+                assertBadCustomDelim(pattern = r'-(.+?)' + c)
+
+        with self.subTest('custom groups must capture exactly one substring'):
+            assertBadCustomDelim(pattern = r'-.*?-') # no captures
+            assertBadCustomDelim(pattern = r'-(.*?):(.*?)-') # too many captures
+
+        with self.subTest('blankDelimiter must not match empty string'):
+            assertBadCustomDelim(pattern='.*')
+
+        with self.subTest('blankDelimiter must adhere to schema'):
+            assertBadCustomDelim(0)
+            assertBadCustomDelim('')
+            assertBadCustomDelim([])
+            assertBadCustomDelim(badSchema = '-')
+
+    def test_standard_input(self):
+        """ Generates a standard input (polynomial_evaluation.py) and tests the output """
+        q_lines = (
+            'Write a function <code>poly</code> that calculates the values of a  ',
+            'polynomial with the given coefficients at the given value of <code>x</code>,',
+            '\tie, evaluate $$f(x) = \sum_i \textrm{coeffs}_i ~ x^i$$\t'
+        )
+        q_text = "\n".join(q_lines)
+        q_trim = "\n".join(map(str.rstrip, q_lines))
+
+        setup = lines(
+            'a: int = 3',
+            'b = a + 4',
+            'l: list[int] = [1, 2, 3]',
+            'c = l[0] = 3'
+        )
+
+        raw = lines(
+            'def poly(coeffs, x): #0given',
+            '    # Keep track of the total as we iterate through each term.',
+            '    # Each term is of the form coeff*(x**power).',
+            '    total = ?0? #blank test #1given # total starts at 0',
+            '    ',
+            '    # Extract the power and coefficient for each term.',
+            '    for ?power, coeff? in enumerate(coeffs):',
+            '        # Add the value of the term to the total.',
+            '        ?total? = total + coeff * (x ** power) #2given',
+            '    return total #1given',
+        )
+
+        ans = lines(
+            'def poly(coeffs, x):',
+            '    # Keep track of the total as we iterate through each term.',
+            '    # Each term is of the form coeff*(x**power).',
+            '    total = 0 # total starts at 0',
+            '',
+            '    # Extract the power and coefficient for each term.',
+            '    for power, coeff in enumerate(coeffs):',
+            '        # Add the value of the term to the total.',
+            '        total = total + coeff * (x ** power)',
+            '    return total',
+        )
+        ppt = lines(
+            'def poly(coeffs, x): #0given',
+            '    total = !BLANK #blank test #1given',
+            '    for !BLANK in enumerate(coeffs):',
+            '        !BLANK = total + coeff * (x ** power) #2given',
+            '    return total #1given',
+        )
+
+        test = lines(
+            'from pl_helpers import name, points',
+            'from pl_unit_test import PLTestCase',
+            'from code_feedback import Feedback',
+            '',
+            'class Test(PLTestCase):',
+            '    @points(1)',
+            '    @name("testing single case")',
+            '    def test_0(self):',
+            '        case = [[10], 3]',
+            '        points = 0',
+            '        user_val = Feedback.call_user(self.st.poly, *case)',
+            '        ref_val = self.ref.poly(*case)',
+            '        if Feedback.check_scalar(f"args: {case}", ref_val, user_val):',
+            '            points += 1',
+            '        Feedback.set_score(points)',
+            ''
+        )
+
+        src = lines(
+            f'"""{q_text}"""',
+            '',
+            make_region('setup_code', setup),
+            '',
+            raw,
+            '',
+            '',
+            make_region('test', test),
+            ''
+        )
+
+        self.assertParsesTo(
+            src,
+            answer_code = ans,
+            prompt_code = ppt,
+            test = test.strip(),
+            setup_code = setup,
+            question_text = q_trim,
+        )
+
+
+main()


### PR DESCRIPTION
This refactoring achieves three goals:
1. Separating the old generator into two stages: lexing and parsing.
  - Lexing yields tokens that are marked with their regions, and is only responsible for dicing a source file into regions. It does not handle any FPP specific content.
  - Parsing deals with fading and file authoring. It generates the content that will be run by PL.
2. TDD is now possible, and a test suite was written for the lexer and parser.
3. A metadata special region was added as a way to configure the parser and provide question-scope data for autograders. It accepts the JSON format which is a subset of the Python dict literal syntax (excluding `null`).